### PR TITLE
FAB-16353 Remove PayloadVisbility field

### DIFF
--- a/peer/proposal.proto
+++ b/peer/proposal.proto
@@ -204,18 +204,8 @@ SignedTransaction
 // chaincode to invoke and what should appear on the ledger.
 message ChaincodeHeaderExtension {
 
-    // The PayloadVisibility field controls to what extent the Proposal's payload
-    // (recall that for the type CHAINCODE, it is ChaincodeProposalPayload
-    // message) field will be visible in the final transaction and in the ledger.
-    // Ideally, it would be configurable, supporting at least 3 main visibility
-    // modes:
-    // 1. all bytes of the payload are visible;
-    // 2. only a hash of the payload is visible;
-    // 3. nothing is visible.
-    // Notice that the visibility function may be potentially part of the ESCC.
-    // In that case it overrides PayloadVisibility field.  Finally notice that
-    // this field impacts the content of ProposalResponsePayload.proposalHash.
-    bytes payload_visibility = 1;
+    reserved 1;
+    reserved "payload_visbility";
 
     // The ID of the chaincode to target.
     ChaincodeID chaincode_id = 2;

--- a/peer/proposal_response.proto
+++ b/peer/proposal_response.proto
@@ -63,17 +63,7 @@ message ProposalResponsePayload {
     // link a response with its proposal, both for bookeeping purposes on an
     // asynchronous system and for security reasons (accountability,
     // non-repudiation). The hash usually covers the entire Proposal message
-    // (byte-by-byte). However this implies that the hash can only be verified
-    // if the entire proposal message is available when ProposalResponsePayload is
-    // included in a transaction or stored in the ledger. For confidentiality
-    // reasons, with chaincodes it might be undesirable to store the proposal
-    // payload in the ledger.  If the type is CHAINCODE, this is handled by
-    // separating the proposal's header and
-    // the payload: the header is always hashed in its entirety whereas the
-    // payload can either be hashed fully, or only its hash may be hashed, or
-    // nothing from the payload can be hashed. The PayloadVisibility field in the
-    // Header's extension controls to which extent the proposal payload is
-    // "visible" in the sense that was just explained.
+    // (byte-by-byte).
     bytes proposal_hash = 1;
 
     // Extension should be unmarshaled to a type-specific message. The type of


### PR DESCRIPTION
This field is only ever referenced in the endorserment proposal
validation (not in commit validation) and is of no use and only adds
confusion.  Removing.

Change-Id: Icd7b7d1a70310d8d41cea43d52d4365c996ce861
Signed-off-by: Jason Yellick <jyellick@us.ibm.com>