### PR TITLE
[FAB-14156] create chaincode server

### DIFF
--- a/peer/chaincode_shim.proto
+++ b/peer/chaincode_shim.proto
@@ -177,3 +177,9 @@ message StateMetadataResult {
 service ChaincodeSupport {
     rpc Register(stream ChaincodeMessage) returns (stream ChaincodeMessage);
 }
+
+// Chaincode as a server - peer establishes a connection to the chaincode as a client
+// Currently only supports a stream connection.
+service Chaincode {
+    rpc Connect(stream ChaincodeMessage) returns (stream ChaincodeMessage);
+}


### PR DESCRIPTION
Chaincode service definition that allows a Peer to "Connect" as q client.
Currently supports only streams but eventually can be extended to support
unary Invoke calls.

Signed-off-by: muralisr <srinivasan.muralidharan99@gmail.com>