### PR TITLE
Add CODEOWNERS to fabric-protos repo

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Fabric Maintainers
+*	@ale-linux @binhn @c0rwin @christo4ferris @denyeart @guoger @JonathanLevi @jyellick @kchristidis @manish-sethi @mastersingh24 @muralisrini @sykesm @yacovm


### PR DESCRIPTION
Populate CODEOWNERS with the current list of Hyperledger Fabric maintainers.