### PR TITLE
FAB-15817 Deprecate LAST_CONFIG metadata field

### DIFF
--- a/common/common.proto
+++ b/common/common.proto
@@ -40,13 +40,13 @@ enum HeaderType {
 
 // This enum enlists indexes of the block metadata array
 enum BlockMetadataIndex {
-    SIGNATURES = 0;                  // Block metadata array position for block signatures
-    LAST_CONFIG = 1;                 // Block metadata array position to store last configuration block sequence number
-    TRANSACTIONS_FILTER = 2;         // Block metadata array position to store serialized bit array filter of invalid transactions
-    ORDERER = 3 [deprecated=true];   /* Block metadata array position to store operational metadata for orderers
-                                        e.g. For Kafka, this is where we store the last offset written to the local ledger */
-    COMMIT_HASH = 4;                 /* Block metadata array position to store the hash of TRANSACTIONS_FILTER, State Updates,
-                                        and the COMMIT_HASH of the previous block */
+    SIGNATURES = 0;                    // Block metadata array position for block signatures
+    LAST_CONFIG = 1 [deprecated=true]; // Block metadata array position to store last configuration block sequence number
+    TRANSACTIONS_FILTER = 2;           // Block metadata array position to store serialized bit array filter of invalid transactions
+    ORDERER = 3 [deprecated=true];     /* Block metadata array position to store operational metadata for orderers
+                                          e.g. For Kafka, this is where we store the last offset written to the local ledger */
+    COMMIT_HASH = 4;                   /* Block metadata array position to store the hash of TRANSACTIONS_FILTER, State Updates,
+                                          and the COMMIT_HASH of the previous block */
 }
 
 // LastConfig is the encoded value for the Metadata message which is encoded in the LAST_CONFIGURATION block metadata index


### PR DESCRIPTION
The last config index is now included in the SIGNATURES
metadata field.

Signed-off-by: Will Lahti <wtlahti@us.ibm.com>