### PR TITLE
[FAB-17303] Support new organization configuration field in channel config

### DIFF
--- a/peer/configuration.proto
+++ b/peer/configuration.proto
@@ -32,3 +32,9 @@ message APIResource {
 message ACLs {
     map<string, APIResource> acls = 1;
 }
+
+// PrivateDataImplicitCollection stores the configuration for org-specific implicit collections
+message PrivateDataImplicitCollection {
+    int32 max_peer_count = 1;
+    int32 required_peer_count = 2;
+}


### PR DESCRIPTION
* PrivateDataImplicitCollectionConfig stores the configuration for
org-specific implicit collections
