### PR TITLE
Extend discovery protos for FAB-17308

### DIFF
--- a/discovery/protocol.proto
+++ b/discovery/protocol.proto
@@ -156,6 +156,8 @@ message ChaincodeInterest {
 message ChaincodeCall {
     string name = 1;
     repeated string collection_names = 2;
+    bool no_private_reads = 3; // Indicates we do not need to read from private data
+    bool no_public_writes = 4; // Indicates we do not need to write to the chaincode namespace
 }
 
 // ChaincodeQueryResult contains EndorsementDescriptors for


### PR DESCRIPTION
Currently, when a client queries discovery with an endorsement query which has collections in the query, discovery intersects the available peers with the collection definition by removing peers which are not part of the collection since they do not have the pre-images required to read from the namespace.

However, the introduction of GetPrivateDataHash makes new use cases possible, namely scenarios where some of the endorsers of a transaction aren't in the collection, but they are fed with the pre-image via other means (e.g the transient field) and after validating the pre-image using GetPrivateDataHash, they can perform the same computation as peers that are in the collection. In such a case, discovery will filter out those peers needlessly.

Furthermore, we want to be able to support writes to collections that have their own endorsement policy, while at the same time the membership of the collections might not even intersect (e.g if we have an org specific collection and we want to delete a key from collection "orgA" and write it into collection "orgB").

The above use cases require the ability to convey to discovery not to filter out peers based on collection association.

Additionally and independently, we sometimes want to do a chaincode-to-chaincode transaction where some of the chaincodes are used for read only, and then we don't want to take into account the endorsement policy, however it can be useful if discovery would still be aware of this so it can filter out peers that do not have the chaincode installed.

To support all the above, I am adding 2 new flags (3 and 4 below) in the ChaincodeCall protobuf message:

Signed-off-by: yacovm <yacovm@il.ibm.com>