### PR TITLE
[FAB-17432] Extend lifecycle protos to query the approved chaincode

### DIFF
--- a/peer/lifecycle/lifecycle.proto
+++ b/peer/lifecycle/lifecycle.proto
@@ -161,6 +161,26 @@ message CheckCommitReadinessResult{
     map<string, bool> approvals = 1;
 }
 
+// QueryApprovedChaincodeDefinitionArgs is the message used as arguments to
+// `_lifecycle.QueryApprovedChaincodeDefinition`.
+message QueryApprovedChaincodeDefinitionArgs {
+    string name = 1;
+    int64 sequence = 2;
+}
+
+// QueryApprovedChaincodeDefinitionResult is the message returned by
+// `_lifecycle.QueryApprovedChaincodeDefinition`.
+message QueryApprovedChaincodeDefinitionResult {
+    int64 sequence = 1;
+    string version = 2;
+    string endorsement_plugin = 3;
+    string validation_plugin = 4;
+    bytes validation_parameter = 5;
+    protos.CollectionConfigPackage collections = 6;
+    bool init_required = 7;
+    ChaincodeSource source = 8;
+}
+
 // QueryChaincodeDefinitionArgs is the message used as arguments to
 // `_lifecycle.QueryChaincodeDefinition`.
 message QueryChaincodeDefinitionArgs {


### PR DESCRIPTION
This patch extends lifecycle protos to add a function for querying the details of the approved chaincode definition.

Signed-off-by: Tatsuya Sato <Tatsuya.Sato@hal.hitachi.com>

#### Type of change

- New feature

#### Description

Currently, Fabric peer does not provide a function to query the details of approved chaincode definitions.

On the other hand, Fabric admins will need to confirm/use the information after approval for their operations.

So, we propose to add a function for querying the details of the approved chaincode definition to Fabric peer CLI (Refer to https://jira.hyperledger.org/browse/FAB-17401).

As a sub-task of FAB-17401, this patch extends lifecycle protos to add a function for querying the details of the approved chaincode definition.

Immediately after this patch has been merged into the fabric repository,  I will submit the following related patches:
- https://github.com/satota2/fabric/commit/956533d0d262c88c31644d14b1885ff64c69018b
- https://github.com/satota2/fabric/commit/005274df67ef807812b50a96b35b6b16efe68dfb
- https://github.com/satota2/fabric/commit/2a257a0d713bfd16d7c2f9a15ed0a109fd806f8f
- https://github.com/satota2/fabric/commit/bd789e139964b6a229b07502432b0264379ab21e

#### Related issues
- Main: 
  - https://jira.hyperledger.org/projects/FAB/issues/FAB-17432

- Others: 
  - https://jira.hyperledger.org/projects/FAB/issues/FAB-17401
  - https://jira.hyperledger.org/projects/FAB/issues/FAB-17433
  - https://jira.hyperledger.org/projects/FAB/issues/FAB-17434
  - https://jira.hyperledger.org/projects/FAB/issues/FAB-17435
  - https://jira.hyperledger.org/projects/FAB/issues/FAB-17436
