### PR TITLE
[FAB-17674] Add Probe flag to ConnEstablish

### DIFF
--- a/gossip/message.proto
+++ b/gossip/message.proto
@@ -175,6 +175,7 @@ message ConnEstablish {
     bytes pki_id          = 1;
     bytes identity        = 2;
     bytes tls_cert_hash   = 3;
+    bool probe            = 4;
 }
 
 // PeerIdentity defines the identity of the peer


### PR DESCRIPTION
Part of FAB-17672:

Gossip bootstrap peer and anchor peer connection establishments are a two step process:

I)  Connect to the remote endpoint, and figure out its organization association
II) Connect to the remote endpoint once again, this time sending membership information according to what it is eligible to.

Unfortunately, if the responding peer connects to the initiator peer at the same time, the connection of (1) will be overwritten by the connection (gossip keeps a single connection among every pair of peers) from the responder peer and the initiator peer will consider the responder peer as dead.

In production, where peers run for a long time and constnatly retry, this is not a problem.

However, in integration tests that expect data to be disseminated in a timely manner, this might cause flakes.

this change set adds a flag that indicates this connection is not a long lasting one, and thus there is no point to add it to the connection store.

Signed-off-by: yacovm <yacovm@il.ibm.com>