### PR TITLE
Update go and prototool versions for CI

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -3,9 +3,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ARG DEBIAN_BASE=buster
-ARG GO_VER=1.12.7
+ARG GO_VER=1.14.1
 ARG PROTOC_VER=1.3.2
-ARG PROTOTOOL_VER=1.8.0
+ARG PROTOTOOL_VER=1.9.0
 
 FROM golang:${GO_VER}-${DEBIAN_BASE} as golang
 RUN mkdir -p /tools

--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -16,7 +16,7 @@ variables:
 pool:
   vmImage: ubuntu-16.04
 container:
-  image: sykesm/fabric-protos:0.1
+  image: sykesm/fabric-protos:0.2
 
 steps:
 - checkout: self


### PR DESCRIPTION
go-1.14.1
prototool-1.9.0

The protoc dependency was not updated as it requires a newer version of grpc-go that may impact existing clients.