### PR TITLE
[FAB-18117] Add client_identity and rename height to block_number in snapshot.proto

### DIFF
--- a/peer/snapshot.proto
+++ b/peer/snapshot.proto
@@ -10,29 +10,37 @@ option java_package = "org.hyperledger.fabric.protos.peer";
 package protos;
 
 import "google/protobuf/empty.proto";
+import "common/common.proto";
 
 // SnapshotRequest contains information for a generate/cancel snapshot request
 message SnapshotRequest {
-    string channel_id = 1;
-    uint64 height = 2;
+    // The signature header that contains creator identity and nonce
+    common.SignatureHeader signature_header = 1;
+    // The channel ID
+    string channel_id = 2;
+    // The block number to generate a snapshot
+    uint64 block_number = 3;
 }
 
 // SnapshotQuery contains information for a query snapshot request
 message SnapshotQuery {
-    string channel_id = 1;
+    // The signature header that contains creator identity and nonce
+    common.SignatureHeader signature_header = 1;
+    // The channel ID
+    string channel_id = 2;
 }
 
 // SignedSnapshotRequest contains marshalled request bytes and signature
 message SignedSnapshotRequest {
     // The bytes of SnapshotRequest or SnapshotQuery
     bytes request = 1;
-    // Signaure over request bytes; this signature is to be verified against the creator identity
+    // Signaure over request bytes; this signature is to be verified against the client identity
     bytes signature = 2;
 }
 
 // QueryPendingSnapshotsResponse specifies the response payload of a query pending snapshots request
 message QueryPendingSnapshotsResponse {
-    repeated uint64 heights = 1;
+    repeated uint64 block_numbers = 1;
 }
 
 service Snapshot {


### PR DESCRIPTION
Signed-off-by: Wenjian Qiao <wenjianq@gmail.com>

Update snapshot.proto to include client_identity and rename `height` to `block_number`