### PR TITLE
[FAB-18235] Add NextAvailable seek position to ab.proto

### DIFF
--- a/orderer/ab.proto
+++ b/orderer/ab.proto
@@ -26,11 +26,15 @@ message SeekSpecified {
     uint64 number = 1;
 }
 
+// SeekNextCommit refers to the next block that will be committed
+message SeekNextCommit { }
+
 message SeekPosition {
     oneof Type {
         SeekNewest newest = 1;
         SeekOldest oldest = 2;
         SeekSpecified specified = 3;
+        SeekNextCommit next_commit = 4;
     }
 }
 


### PR DESCRIPTION
This option is added to allow a client listens to the future blocks only,
comparing to the existing Newest option which refers to the last block
that has been committed on the ledgerr.

Signed-off-by: Wenjian Qiao <wenjianq@gmail.com>