### PR TITLE
FABGW-1 Add proto definition for gateway

### DIFF
--- a/gateway/gateway.proto
+++ b/gateway/gateway.proto
@@ -1,0 +1,79 @@
+// Copyright the Hyperledger Fabric contributors. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+syntax = "proto3";
+
+option go_package = "github.com/hyperledger/fabric-protos-go/gateway";
+option java_multiple_files = true;
+option java_package = "org.hyperledger.fabric.protos.gateway";
+option java_outer_classname = "GatewayProto";
+
+package protos;
+
+import "peer/proposal.proto";
+import "common/common.proto";
+
+// The Gateway API for evaluating and submitting transactions via the gateway.
+// Transaction evaluation (query) requires the invocation of the Evaluate service
+// Transaction submission (ledger updates) is a two step process invoking Endorse
+// followed by Submit.  The proposal and transaction must be signed by the client
+// before each step.
+service Gateway {
+    // The Endorse service passes the ProposedTransaction (which contains the signed proposal)
+    // to the gateway in order to obtain sufficient endorsement.
+    // The gateway will determine the endorsement plan for the requested chaincode and
+    // forward to the appropriate peers for endorsement. It will return to the client a
+    // PreparedTransaction message which contains a Envelope message as defined
+    // in fabric-protos/common/common.proto.  The client must sign the contents of this
+    // envelope before invoking the Submit service
+    rpc Endorse(ProposedTransaction) returns (PreparedTransaction);
+
+    // Ths Submit service will process the PreparedTransaction message returned from Endorse service
+    // once it has been signed by the client. A stream is opened to return multiple return values.
+    // - The Gateway will register transaction event listeners for the given channel/txId.
+    // - It will then broadcast the Envelope to the ordering service.
+    // - The success/error response is passed back to the client in the stream
+    // - The Gateway awaits sufficient transaction commit events before returning and closing the stream,
+    //   indicating to the client that transaction has been committed.
+    rpc Submit(PreparedTransaction) returns (stream Event);
+
+    // The Evaluate service passes the ProposedTransaction (which contains the signed proposal)
+    // to the gateway in order to invoke the transaction function and return the result to the client.
+    // No ledger updates are make.  The gateway will select an appropriate peer to query based on
+    // block height and load.
+    rpc Evaluate(ProposedTransaction) returns (Result);
+}
+
+// Result is the value that is returned by the transaction function.
+message Result {
+    // The byte array returned from the chaincode invocation.
+    bytes value = 1;
+}
+
+// ProposedTransaction contains the signed proposal ready for endorsement plus any processing options.
+message ProposedTransaction {
+    // The signed proposal.
+    SignedProposal proposal = 1;
+    // Other options will be added here.  The following are experimental at the moment.
+    string tx_id = 2;
+    string channel_id = 3;
+}
+
+// PreparedTransaction contains the set of transaction responses from the endorsing peers for signing by the client
+// before submitting to ordering service (via gateway).
+message PreparedTransaction {
+    // The transaction envelope.
+    common.Envelope envelope = 1;
+    // The value that is returned by the transaction function during endorsement.
+    Result response = 2;
+    // The following fields are pulled out of the envelope to the top level for convenience to the client.
+    string tx_id = 3;
+    string channel_id = 4;
+}
+
+// Event contains the data returned in the stream from the Submit service.
+// This is currently experimental and highly likely to change during gateway development.
+message Event {
+    bytes value = 1;
+}


### PR DESCRIPTION
The proto definition required by the gateway component. 
Moving from fabric-gateway repo to core fabric-protos to support embedding of gateway into peer

Signed-off-by: andrew-coleman <andrew_coleman@uk.ibm.com>