### PR TITLE
Add error details to gateway proto

### DIFF
--- a/gateway/gateway.proto
+++ b/gateway/gateway.proto
@@ -77,3 +77,18 @@ message PreparedTransaction {
 message Event {
     bytes value = 1;
 }
+
+// If any of the functions in the Gateway service returns an error, then it will be in the format of
+// a google.rpc.Status message. The 'details' field of this message will be populated with extra
+// information if the error is a result of one or more failed requests to remote peers or orderer nodes.
+// EndpointError contains details of errors that are received by any of the endorsing peers
+// as a result of processing the Evaluate or Endorse services, or from the ordering node(s) as a result of
+// processing the Submit service.
+message EndpointError {
+    // The address of the endorsing peer or ordering node that returned an error.
+    string address = 1;
+    // The MSP Identifier of this endpoint.
+    string msp_id = 2;
+    // The error message returned by this endpoint.
+    string message = 3;
+}


### PR DESCRIPTION
The functions exposed by the gateway service make grpc client requests to external peers and orderers.  If any of these requests return an error, then these errors including the address of the remote endpoint are added to the Details field of the error returned by the gateway service.

This commit adds the message definition to the proto file to enable this capability.

Signed-off-by: andrew-coleman <andrew_coleman@uk.ibm.com>