### PR TITLE
FABGW-20 Specify endorsing organizations

### DIFF
--- a/gateway/gateway.proto
+++ b/gateway/gateway.proto
@@ -58,6 +58,9 @@ message EndorseRequest {
     string channel_id = 2;
     // The signed proposal ready for endorsement.
     protos.SignedProposal proposed_transaction = 3;
+    // If targeting the peers of specific organizations (e.g. for private data scenarios),
+    // the list of organizations should be supplied here.
+    repeated string endorsing_organizations = 4;
 }
 
 // EndorseResponse returns the result of endorsing a transaction.


### PR DESCRIPTION
Add support in the EndorseRequest message of the gateway proto for specifying which org’s peers to target.

Signed-off-by: andrew-coleman <andrew_coleman@uk.ibm.com>