### PR TITLE
FABGW-21: Add Gateway ChaincodeEvents service

### DIFF
--- a/gateway/gateway.proto
+++ b/gateway/gateway.proto
@@ -11,6 +11,7 @@ option java_outer_classname = "GatewayProto";
 
 package gateway;
 
+import "peer/chaincode_event.proto";
 import "peer/proposal.proto";
 import "peer/proposal_response.proto";
 import "peer/transaction.proto";
@@ -29,7 +30,7 @@ service Gateway {
     // forward to the appropriate peers for endorsement. It will return to the client a
     // prepared transaction in the form of an Envelope message as defined
     // in common/common.proto. The client must sign the contents of this envelope
-    // before invoking the Submit service
+    // before invoking the Submit service.
     rpc Endorse(EndorseRequest) returns (EndorseResponse);
 
     // The Submit service will process the prepared transaction returned from Endorse service
@@ -47,6 +48,12 @@ service Gateway {
     // transaction function and return the result to the client. No ledger updates are made.
     // The gateway will select an appropriate peer to query based on block height and load.
     rpc Evaluate(EvaluateRequest) returns (EvaluateResponse);
+
+    // The ChaincodeEvents service supplies a stream of responses, each containing all the events emitted by the
+    // requested chaincode for a specific block. The streamed responses are ordered by ascending block number. Responses
+    // are only returned for blocks that contain the requested events, while blocks not containing any of the requested
+    // events are skipped.
+    rpc ChaincodeEvents(SignedChaincodeEventsRequest) returns (stream ChaincodeEventsResponse);
 }
 
 // EndorseRequest contains the details required to obtain sufficient endorsements for a
@@ -66,7 +73,7 @@ message EndorseRequest {
 // EndorseResponse returns the result of endorsing a transaction.
 message EndorseResponse {
     // The response that is returned by the transaction function, as defined
-    // in peer/proposal_response.proto
+    // in peer/proposal_response.proto.
     protos.Response result = 1;
     // The unsigned set of transaction responses from the endorsing peers for signing by the client
     // before submitting to ordering service (via gateway).
@@ -91,7 +98,7 @@ message SubmitResponse {
 // SignedCommitStatusRequest contains a serialized CommitStatusRequest message, and a digital signature for the
 // serialized request message.
 message SignedCommitStatusRequest {
-    // Serialized CommitStatusRequest message
+    // Serialized CommitStatusRequest message.
     bytes request = 1;
     // Signature for request message.
     bytes signature = 2;
@@ -110,8 +117,10 @@ message CommitStatusRequest {
 
 // CommitStatusResponse returns the result of committing a transaction.
 message CommitStatusResponse {
-    // The result of the transaction commit, as defined in peer/transaction.proto
+    // The result of the transaction commit, as defined in peer/transaction.proto.
     protos.TxValidationCode result = 1;
+    // Block number that contains the transaction.
+    uint64 block_number = 2;
 }
 
 // EvaluateRequest contains the details required to evaluate a transaction (query the ledger).
@@ -127,8 +136,36 @@ message EvaluateRequest {
 // EvaluateResponse returns the result of evaluating a transaction.
 message EvaluateResponse {
     // The response that is returned by the transaction function, as defined
-    // in peer/proposal_response.proto
+    // in peer/proposal_response.proto.
     protos.Response result = 1;
+}
+
+// SignedChaincodeEventsRequest contains a serialized ChaincodeEventsRequest message, and a digital signature for the
+// serialized request message.
+message SignedChaincodeEventsRequest {
+    // Serialized ChaincodeEventsRequest message.
+    bytes request = 1;
+    // Signature for request message.
+    bytes signature = 2;
+}
+
+// ChaincodeEventsRequest contains details of the chaincode events that the caller wants to receive.
+message ChaincodeEventsRequest {
+    // Identifier of the channel this request is bound for.
+    string channel_id = 1;
+    // Name of the chaincode for which events are requested.
+    string chaincode_id = 2;
+    // Client requestor identity.
+    bytes identity = 3;
+}
+
+// ChaincodeEventsResponse returns chaincode events emitted from a specific block.
+message ChaincodeEventsResponse {
+    // Chaincode events emitted by the requested chaincode. The events are presented in the same order that the
+    // transactions that emitted them appear within the block.
+    repeated protos.ChaincodeEvent events = 1;
+    // Block number in which the chaincode events were emitted.
+    uint64 block_number = 2;
 }
 
 // If any of the functions in the Gateway service returns an error, then it will be in the format of


### PR DESCRIPTION
This service supports chaincode event listening in the client API.