### PR TITLE
FABGW-25 Extend proto to include derived interest

### DIFF
--- a/discovery/protocol.proto
+++ b/discovery/protocol.proto
@@ -11,6 +11,7 @@ package discovery;
 
 import "gossip/message.proto";
 import "msp/msp_config.proto";
+import "peer/proposal_response.proto";
 
 // Discovery defines a service that serves information about the fabric network
 // like which peers, orderers, chaincodes, etc.
@@ -128,7 +129,7 @@ message ConfigResult {
 // chaincodes that are installed on peers and collection
 // access control policies.
 message PeerMembershipQuery {
-    ChaincodeInterest filter = 1;
+    protos.ChaincodeInterest filter = 1;
 }
 
 // PeerMembershipResult contains peers mapped by their organizations (MSP_ID)
@@ -141,23 +142,7 @@ message PeerMembershipResult {
 // Each invocation is a separate one, and the endorsement policy
 // is evaluated independantly for each given interest.
 message ChaincodeQuery {
-    repeated ChaincodeInterest interests = 1;
-}
-
-// ChaincodeInterest defines an interest about an endorsement
-// for a specific single chaincode invocation.
-// Multiple chaincodes indicate chaincode to chaincode invocations.
-message ChaincodeInterest {
-    repeated ChaincodeCall chaincodes = 1;
-}
-
-// ChaincodeCall defines a call to a chaincode.
-// It may have collections that are related to the chaincode
-message ChaincodeCall {
-    string name = 1;
-    repeated string collection_names = 2;
-    bool no_private_reads = 3; // Indicates we do not need to read from private data
-    bool no_public_writes = 4; // Indicates we do not need to write to the chaincode namespace
+    repeated protos.ChaincodeInterest interests = 1;
 }
 
 // ChaincodeQueryResult contains EndorsementDescriptors for

--- a/peer/proposal_response.proto
+++ b/peer/proposal_response.proto
@@ -11,6 +11,7 @@ option java_outer_classname = "ProposalResponsePackage";
 package protos;
 
 import "google/protobuf/timestamp.proto";
+import "common/policies.proto";
 
 // A ProposalResponse is returned from an endorser to the proposal submitter.
 // The idea is that this message contains the endorser's response to the
@@ -38,6 +39,9 @@ message ProposalResponse {
     // The endorsement of the proposal, basically
     // the endorser's signature over the payload
     Endorsement endorsement = 6;
+
+    // The chaincode interest derived from simulating the proposal.
+    ChaincodeInterest interest = 7;
 }
 
 // A response with a representation similar to an HTTP response that can
@@ -91,3 +95,24 @@ message Endorsement {
     // the endorser's certificate; ie, sign(ProposalResponse.payload + endorser)
     bytes signature = 2;
 }
+
+// ChaincodeInterest defines an interest about an endorsement
+// for a specific single chaincode invocation.
+// Multiple chaincodes indicate chaincode to chaincode invocations.
+message ChaincodeInterest {
+    repeated ChaincodeCall chaincodes = 1;
+}
+
+// ChaincodeCall defines a call to a chaincode.
+// It may have collections that are related to the chaincode
+message ChaincodeCall {
+    string name = 1;
+    repeated string collection_names = 2;
+    bool no_private_reads = 3; // Indicates we do not need to read from private data
+    bool no_public_writes = 4; // Indicates we do not need to write to the chaincode namespace
+
+    // The set of signature policies associated with states in the write-set
+    // that have state-based endorsement policies.
+    repeated common.SignaturePolicyEnvelope key_policies = 5;
+}
+


### PR DESCRIPTION
Add protobuf support for returning the derived chaincode interest structure from Tx simulation (process proposal).

Add the set of SBE signature policies to the discovery ChaincodeCall proto message
Add the ChaincodeInterest structure to the ProposalResponse message

Signed-off-by: andrew-coleman <andrew_coleman@uk.ibm.com>