### PR TITLE
[FAB-18527] Hint to discovery to disregard the namespace endorsement policy

### DIFF
--- a/peer/proposal_response.proto
+++ b/peer/proposal_response.proto
@@ -114,5 +114,8 @@ message ChaincodeCall {
     // The set of signature policies associated with states in the write-set
     // that have state-based endorsement policies.
     repeated common.SignaturePolicyEnvelope key_policies = 5;
+
+    // Indicates we wish to ignore the namespace endorsement policy
+    bool disregard_namespace_policy = 6;
 }
 


### PR DESCRIPTION
    
This commit adds a hint in the chaincode call of the discovery protobuf API
to signal that the client expects the namespace endorsement policy to be irrelevant.


Signed-off-by: Yacov Manevich <yacovm@il.ibm.com>