### PR TITLE
Update Go to 1.16.7

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ARG DEBIAN_BASE=buster
-ARG GO_VER=1.14.1
+ARG GO_VER=1.16.7
 ARG PROTOC_VER=1.3.2
 ARG PROTOTOOL_VER=1.9.0
 


### PR DESCRIPTION
Update Go to 1.16.7.

Signed-off-by: David Enyeart <enyeart@us.ibm.com>