### PR TITLE
JavaScript binding hint for block number in SeekSpecified

### DIFF
--- a/orderer/ab.proto
+++ b/orderer/ab.proto
@@ -23,7 +23,7 @@ message SeekNewest { }
 message SeekOldest { }
 
 message SeekSpecified {
-    uint64 number = 1;
+    uint64 number = 1 [jstype = JS_STRING];
 }
 
 // SeekNextCommit refers to the next block that will be committed


### PR DESCRIPTION
Default protoc binding is to JavaScript number, which cannot hold a full 64-bit value. This change supports Fabric Gateway Node client API for chaincode event replay.