### PR TITLE
Add `is_purge` field to KVWriteHash

### DIFF
--- a/ledger/rwset/kvrwset/kv_rwset.proto
+++ b/ledger/rwset/kvrwset/kv_rwset.proto
@@ -58,6 +58,7 @@ message KVWriteHash {
     bytes key_hash = 1;
     bool is_delete = 2;
     bytes value_hash = 3;
+    bool is_purge = 4;
 }
 
 // KVMetadataWriteHash captures all the upserts to the metadata associated with a key hash


### PR DESCRIPTION
This PR adds a field to capture the is_purge operation for enabling the purge of private data.

[Issue on fabric repo](https://github.com/hyperledger/fabric/issues/3021)

Signed-off-by: manish <manish.sethi@gmail.com>