### PR TITLE
Allow ChaincodeEvents to resume after a specific transaction ID

### DIFF
--- a/gateway/gateway.proto
+++ b/gateway/gateway.proto
@@ -160,6 +160,10 @@ message ChaincodeEventsRequest {
     bytes identity = 3;
     // Position within the ledger at which to start reading events.
     orderer.SeekPosition start_position = 4;
+    // Only returns events after this transaction ID. Transactions up to and including this one should be ignored. This
+    // is used to allow resume of event listening from a certain position within a start block specified by
+    // start_position.
+    string after_transaction_id = 5;
 }
 
 // ChaincodeEventsResponse returns chaincode events emitted from a specific block.


### PR DESCRIPTION
Add a `after_transaction_id` field to the ChaincodeEventsRequest message so the client can specify a transaction ID, up to which chaincode events should be ignored and not returned to the client.