### PR TITLE
New service and messages for block attestation

### DIFF
--- a/buf.yaml
+++ b/buf.yaml
@@ -46,6 +46,7 @@ lint:
       - common/policies.proto
       - orderer/ab.proto
       - orderer/kafka.proto
+      - orderer/blockattestation.proto
       - peer/events.proto
       - peer/lifecycle/db.proto
       - peer/lifecycle/lifecycle.proto
@@ -113,6 +114,7 @@ lint:
       - orderer/etcdraft/configuration.proto
       - orderer/etcdraft/metadata.proto
       - orderer/kafka.proto
+      - orderer/blockattestation.proto
       - peer/chaincode.proto
       - peer/chaincode_event.proto
       - peer/chaincode_shim.proto
@@ -135,6 +137,7 @@ lint:
     RPC_REQUEST_RESPONSE_UNIQUE:
       - gossip/message.proto
       - orderer/ab.proto
+      - orderer/blockattestation.proto
       - peer/chaincode_shim.proto
       - peer/events.proto
       - peer/snapshot.proto
@@ -143,6 +146,7 @@ lint:
       - gateway/gateway.proto
       - gossip/message.proto
       - orderer/ab.proto
+      - orderer/blockattestation.proto
       - peer/chaincode_shim.proto
       - peer/events.proto
       - peer/peer.proto
@@ -150,6 +154,7 @@ lint:
     RPC_RESPONSE_STANDARD_NAME:
       - discovery/protocol.proto
       - gossip/message.proto
+      - orderer/blockattestation.proto
       - peer/chaincode_shim.proto
       - peer/events.proto
       - peer/peer.proto
@@ -160,6 +165,7 @@ lint:
       - gossip/message.proto
       - orderer/ab.proto
       - orderer/cluster.proto
+      - orderer/blockattestation.proto
       - peer/chaincode_shim.proto
       - peer/events.proto
       - peer/peer.proto

--- a/orderer/blockattestation.proto
+++ b/orderer/blockattestation.proto
@@ -1,0 +1,29 @@
+// Copyright the Hyperledger Fabric contributors. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+syntax = "proto3";
+
+option go_package = "github.com/hyperledger/fabric-protos-go/orderer";
+option java_package = "org.hyperledger.fabric.protos.orderer";
+
+package orderer;
+
+import "common/common.proto";
+
+message BlockAttestation {
+       common.BlockHeader header = 1;
+       common.BlockMetadata metadata = 2;
+}
+
+message BlockAttestationResponse {
+    oneof Type {
+        common.Status status = 1;
+        BlockAttestation block_attestation = 2;
+    }
+}
+
+service BlockAttestations {
+    // BlockAttestations receives an Envelope of type DELIVER_SEEK_INFO , then sends back a stream of BlockAttestations.
+    rpc BlockAttestations(common.Envelope) returns (stream BlockAttestationResponse);
+}


### PR DESCRIPTION
New block attestation service for BFT block replication and verification feature. 

Issue: https://github.com/hyperledger/fabric/issues/3413

Signed-off-by: Parameswaran Selvam <parselva@in.ibm.com>