### PR TITLE
Publish generated API documentation

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -57,6 +57,6 @@ jobs:
       working-directory: publish
 
     - name: Push GitHub pages commit
-      run: git push --force publish-pages:gh-pages
+      run: git push --force origin publish-pages:gh-pages
       if: github.event_name != 'pull_request'
       working-directory: publish


### PR DESCRIPTION
Previous attempt failed with…

ssh: Could not resolve hostname publish-pages: Temporary failure in name resolution
Signed-off-by: James Taylor <jamest@uk.ibm.com>