### PR TITLE
Addressed lint warnings in Blockattestation service

### DIFF
--- a/buf.yaml
+++ b/buf.yaml
@@ -46,7 +46,6 @@ lint:
       - common/policies.proto
       - orderer/ab.proto
       - orderer/kafka.proto
-      - orderer/blockattestation.proto
       - peer/events.proto
       - peer/lifecycle/db.proto
       - peer/lifecycle/lifecycle.proto
@@ -137,7 +136,6 @@ lint:
     RPC_REQUEST_RESPONSE_UNIQUE:
       - gossip/message.proto
       - orderer/ab.proto
-      - orderer/blockattestation.proto
       - peer/chaincode_shim.proto
       - peer/events.proto
       - peer/snapshot.proto
@@ -146,7 +144,6 @@ lint:
       - gateway/gateway.proto
       - gossip/message.proto
       - orderer/ab.proto
-      - orderer/blockattestation.proto
       - peer/chaincode_shim.proto
       - peer/events.proto
       - peer/peer.proto
@@ -154,7 +151,6 @@ lint:
     RPC_RESPONSE_STANDARD_NAME:
       - discovery/protocol.proto
       - gossip/message.proto
-      - orderer/blockattestation.proto
       - peer/chaincode_shim.proto
       - peer/events.proto
       - peer/peer.proto
@@ -165,7 +161,6 @@ lint:
       - gossip/message.proto
       - orderer/ab.proto
       - orderer/cluster.proto
-      - orderer/blockattestation.proto
       - peer/chaincode_shim.proto
       - peer/events.proto
       - peer/peer.proto

--- a/orderer/blockattestation.proto
+++ b/orderer/blockattestation.proto
@@ -16,14 +16,18 @@ message BlockAttestation {
        common.BlockMetadata metadata = 2;
 }
 
-message BlockAttestationResponse {
-    oneof Type {
+message BlockAttestationsRequest {
+    common.Envelope envelope = 1;
+}
+
+message BlockAttestationsResponse {
+    oneof type {
         common.Status status = 1;
         BlockAttestation block_attestation = 2;
     }
 }
 
-service BlockAttestations {
+service BlockAttestationsService {
     // BlockAttestations receives an Envelope of type DELIVER_SEEK_INFO , then sends back a stream of BlockAttestations.
-    rpc BlockAttestations(common.Envelope) returns (stream BlockAttestationResponse);
+    rpc BlockAttestations(BlockAttestationsRequest) returns (stream BlockAttestationsResponse);
 }


### PR DESCRIPTION
Addressed protobuf lint wanring in Blockattestation proto file.


Signed-off-by: Parameswaran Selvam <parselva@in.ibm.com>