### PR TITLE
Fix path to installDeployKey.sh script

### DIFF
--- a/.github/workflows/go-bindings.yml
+++ b/.github/workflows/go-bindings.yml
@@ -65,7 +65,7 @@ jobs:
 
     - name: Push GitHub apiv2 publish commit
       run: |
-        ./.github/scripts/installDeployKey.sh fabric-protos-go-apiv2 $FABRIC_PROTOS_GO_APIV2_DEPLOY_KEY
+        ../build/.github/scripts/installDeployKey.sh fabric-protos-go-apiv2 $FABRIC_PROTOS_GO_APIV2_DEPLOY_KEY
         touch "${HOME}/.ssh/known_hosts"
         ssh-keyscan -H github.com >> "${HOME}/.ssh/known_hosts"
         git remote set-url origin git@github.com-fabric-protos-go-apiv2:hyperledger/fabric-protos-go-apiv2.git


### PR DESCRIPTION
Build failed to find the script due to working-directory being publish-apiv2

Signed-off-by: James Taylor <jamest@uk.ibm.com>