### PR TITLE
Use base64 encoded deploy key

### DIFF
--- a/.github/scripts/installDeployKey.sh
+++ b/.github/scripts/installDeployKey.sh
@@ -6,7 +6,7 @@ deploy_key="${2:?}"
 umask 077
 mkdir -p "${HOME}/.ssh"
 
-echo "${deploy_key}" > "${HOME}/.ssh/${repo}_deploy_key"
+echo ${deploy_key} | base64 --decode > "${HOME}/.ssh/${repo}_deploy_key"
 
 touch "${HOME}/.ssh/config"
 cat << CONFIG-EOF >> "${HOME}/.ssh/config"


### PR DESCRIPTION
The key works locally but fails in the build for some reason…

```
Load key "/home/runner/.ssh/fabric-protos-go-apiv2_deploy_key": invalid format
```

Try using a base64 encoded key instead

Signed-off-by: James Taylor <jamest@uk.ibm.com>