### PR TITLE
Allow release builds to be re-run manually

### DIFF
--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -3,6 +3,9 @@ name: Build checks
 on:
   workflow_call:
     outputs:
+      publish_release:
+        description: "'true' if this is a release build"
+        value: ${{ jobs.check_release.outputs.publish_release }}
       binding_version:
         description: "Current binding version"
         value: ${{ jobs.check_version.outputs.binding_version }}
@@ -11,6 +14,26 @@ env:
   BINDING_VERSION: 0.1.2
 
 jobs:
+  check_release:
+    name: Check release
+    runs-on: ubuntu-latest
+    outputs:
+      publish_release: ${{ steps.check_release_tag.outputs.publish_release }}
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Check release tag
+      id: check_release_tag
+      run: |
+        git fetch --tags origin
+        TAGS=$(git tag --points-at HEAD | { grep -c "^v${BINDING_VERSION}$" || :; })
+        if [ "${GITHUB_EVENT_NAME}" != "pull_request" ] && [ $TAGS -eq 1 ]; then
+          echo "::set-output name=publish_release::true"
+        else
+          echo "::set-output name=publish_release::false"
+        fi
+
   check_version:
     name: Check versions
     runs-on: ubuntu-latest

--- a/.github/workflows/java-bindings.yml
+++ b/.github/workflows/java-bindings.yml
@@ -49,7 +49,7 @@ jobs:
 
     - name: Set prerelease version
       run: mvn --batch-mode versions:set -DnewVersion=${BINDING_VERSION}-dev-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}
-      if: startsWith(github.ref, 'refs/tags/') != true
+      if: needs.ci_checks.outputs.publish_release != 'true'
       working-directory: bindings/java
       env:
         BINDING_VERSION: ${{ needs.ci_checks.outputs.binding_version }}
@@ -58,7 +58,7 @@ jobs:
 
     - name: Set release version
       run: mvn --batch-mode versions:set -DnewVersion=${BINDING_VERSION}
-      if: startsWith(github.ref, 'refs/tags/')
+      if: needs.ci_checks.outputs.publish_release == 'true'
       working-directory: bindings/java
       env:
         BINDING_VERSION: ${{ needs.ci_checks.outputs.binding_version }}
@@ -73,7 +73,7 @@ jobs:
 
     - name: Set up Java for publishing to Maven Central Repository
       uses: actions/setup-java@v3
-      if: startsWith(github.ref, 'refs/tags/')
+      if: needs.ci_checks.outputs.publish_release == 'true'
       with:
         distribution: 'temurin'
         java-version: '8'
@@ -86,7 +86,7 @@ jobs:
 
     - name: Publish to the Maven Central Repository
       run: mvn -P ossrh --batch-mode deploy
-      if: startsWith(github.ref, 'refs/tags/')
+      if: needs.ci_checks.outputs.publish_release == 'true'
       working-directory: bindings/java
       env:
         MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}

--- a/.github/workflows/node-bindings.yml
+++ b/.github/workflows/node-bindings.yml
@@ -49,7 +49,7 @@ jobs:
 
     - run: npm version ${BINDING_VERSION}-dev.${GITHUB_RUN_ID}.${GITHUB_RUN_ATTEMPT}
       name: npm version
-      if: github.event_name != 'release'
+      if: needs.ci_checks.outputs.publish_release != 'true'
       working-directory: bindings/node
       env:
         BINDING_VERSION: ${{ needs.ci_checks.outputs.binding_version }}
@@ -57,9 +57,10 @@ jobs:
         GITHUB_RUN_ATTEMPT: ${{ github.run_attempt }}
 
     - run: |
+        [ "${NPM_CONFIG_DRY_RUN}" == "true" ] && echo "Dry run"
         npm publish --access public --tag latest
       name: npm publish
       working-directory: bindings/node
       env:
-        NPM_CONFIG_DRY_RUN: ${{ ( github.event_name == 'push' || github.event_name == 'release' ) && 'false' || 'true'}}
+        NPM_CONFIG_DRY_RUN: ${{ ( github.ref == 'refs/heads/main' || needs.ci_checks.outputs.publish_release == 'true' ) && 'false' || 'true' }}
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
It would be useful to rerun the release build using the workflow_dispatch event, however this does not currently work because the workflows are checking the github ref for a v* version tag.

It’s not safe to always publish for a manual build and all the language bindings at a particular version should be published from the same commit, so this PR adds a job to the ci-checks workflow to look for the required version tag on the commit being built.

Signed-off-by: James Taylor <jamest@uk.ibm.com>