### PR TITLE
Tag fabric-protos-go-apiv2 repo on release builds

### DIFF
--- a/.github/workflows/go-bindings.yml
+++ b/.github/workflows/go-bindings.yml
@@ -79,3 +79,12 @@ jobs:
       working-directory: publish-apiv2
       env:
         FABRIC_PROTOS_GO_APIV2_DEPLOY_KEY: ${{ secrets.FABRIC_PROTOS_GO_APIV2_DEPLOY_KEY }}
+
+    - name: Tag apiv2 commit
+      run: |
+        git tag v${BINDING_VERSION}
+        git push origin v${BINDING_VERSION}
+      if: needs.ci_checks.outputs.publish_release == 'true'
+      working-directory: publish-apiv2
+      env:
+        BINDING_VERSION: ${{ needs.ci_checks.outputs.binding_version }}


### PR DESCRIPTION
Add version tags to the fabric-protos-go-apiv2 repository to match tagged releases in fabric-protos

Signed-off-by: James Taylor <jamest@uk.ibm.com>