### PR TITLE
Fixed @ CVE-2022-31163

### DIFF
--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -266,7 +266,7 @@ GEM
     thread_safe (0.3.6)
     typhoeus (1.4.0)
       ethon (>= 0.9.0)
-    tzinfo (1.2.9)
+    tzinfo (1.2.10)
       thread_safe (~> 0.1)
     unf (0.1.4)
       unf_ext


### PR DESCRIPTION
Signed-off-by: mik-patient <112659896+mik-patient@users.noreply.github.com>

## Vulnerability Description
With the Ruby data source (the tzinfo-data gem for tzinfo version 1.0.0 and later and built-in to earlier versions), time zones are defined in Ruby files. There is one file per time zone. Time zone files are loaded with require on demand. In the affected versions, `TZInfo::Timezone.get` fails to validate time zone identifiers correctly, allowing a new line character within the identifier. With Ruby version 1.9.3 and later, `TZInfo::Timezone.get` can be made to load unintended files with require, executing them within the Ruby process.
```rb
TZInfo::Timezone.get("foo\n/../../../../../../../../../../../../../../../../tmp/payload")
```
**CVE-2022-31163**
`CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:H/I:H/A:H`
GHSA-5cm2-9h8c-rvfx

