### PR TITLE
Revert to using FABRIC_PROTOS_GO_APIV2_DEPLOY_KEY

### DIFF
--- a/.github/workflows/go-bindings.yml
+++ b/.github/workflows/go-bindings.yml
@@ -68,20 +68,26 @@ jobs:
       env:
         COMMIT_MESSAGE: ${{ steps.get-commit-message.outputs.COMMIT_MESSAGE }}
 
-    - name: Push GitHub apiv2 publish commit
+    - name: Set up apiv2 deploy key
       run: |
-        ../build/.github/scripts/installDeployKey.sh fabric-protos-go-apiv2 ${{ secrets.PUBLISH_GO_V2 }}
+        ../build/.github/scripts/installDeployKey.sh fabric-protos-go-apiv2 $FABRIC_PROTOS_GO_APIV2_DEPLOY_KEY
         touch "${HOME}/.ssh/known_hosts"
         ssh-keyscan -H github.com >> "${HOME}/.ssh/known_hosts"
-        git remote set-url origin https://x-access-token:${{ secrets.PUBLISH_GO_V2 }}@github.com/hyperledger/fabric-protos-go-apiv2.git
+        git remote set-url origin git@github.com-fabric-protos-go-apiv2:hyperledger/fabric-protos-go-apiv2.git
+      if: github.event_name != 'pull_request'
+      working-directory: publish-apiv2
+
+    - name: Push GitHub apiv2 publish commit
+      run: |
         git push origin
       if: github.ref == 'refs/heads/main'
       working-directory: publish-apiv2
+      env:
+        FABRIC_PROTOS_GO_APIV2_DEPLOY_KEY: ${{ secrets.FABRIC_PROTOS_GO_APIV2_DEPLOY_KEY }}
 
     - name: Tag apiv2 commit
       run: |
         git tag v${BINDING_VERSION}
-        git remote set-url origin https://x-access-token:${{ secrets.PUBLISH_GO_V2 }}@github.com/hyperledger/fabric-protos-go-apiv2.git
         git push origin v${BINDING_VERSION}
       if: needs.ci_checks.outputs.publish_release == 'true'
       working-directory: publish-apiv2


### PR DESCRIPTION
The last successfull push to fabric-protos-go-apiv2 was before the update to the PUBLISH_GO_V2 secret so switching back to FABRIC_PROTOS_GO_APIV2_DEPLOY_KEY

Also moved the deploy key setup to a seperate step which should hopefully fix the apiv2 tagging

Signed-off-by: James Taylor <jamest@uk.ibm.com>

<!--- IMPORTANT: DO NOT modify or disable lint rules without agreeing changes in an issue first! -->
<!--- Any changes to lint rules and breaking change detection should be made in a separate pull  -->
<!--- request with an associated issue.                                                          -->
<!--- Please include a link to the issue in the pull request and DO NOT adjust lint rules to fix -->
<!--- build breaks when submitting any other pull requests.                                      -->