### PR TITLE
system channel cleanup - make HeaderType_ORDERER_TRANSACTION deprecated

### DIFF
--- a/common/common.proto
+++ b/common/common.proto
@@ -28,13 +28,13 @@ enum HeaderType {
     reserved 7, 8, 9;
     reserved "PEER_RESOURCE_UPDATE", "PEER_ADMIN_OPERATION", "TOKEN_TRANSACTION";
 
-    MESSAGE = 0;                     // Used for messages which are signed but opaque
-    CONFIG = 1;                      // Used for messages which express the channel config
-    CONFIG_UPDATE = 2;               // Used for transactions which update the channel config
-    ENDORSER_TRANSACTION = 3;        // Used by the SDK to submit endorser based transactions
-    ORDERER_TRANSACTION = 4;         // Used internally by the orderer for management
-    DELIVER_SEEK_INFO = 5;           // Used as the type for Envelope messages submitted to instruct the Deliver API to seek
-    CHAINCODE_PACKAGE = 6;           // Used for packaging chaincode artifacts for install
+    MESSAGE = 0;                                 // Used for messages which are signed but opaque
+    CONFIG = 1;                                  // Used for messages which express the channel config
+    CONFIG_UPDATE = 2;                           // Used for transactions which update the channel config
+    ENDORSER_TRANSACTION = 3;                    // Used by the SDK to submit endorser based transactions
+    ORDERER_TRANSACTION = 4 [deprecated = true]; // Was used internally by the orderer for management, no longer used since system channel was removed
+    DELIVER_SEEK_INFO = 5;                       // Used as the type for Envelope messages submitted to instruct the Deliver API to seek
+    CHAINCODE_PACKAGE = 6;                       // Used for packaging chaincode artifacts for install
 }
 
 // This enum enlists indexes of the block metadata array


### PR DESCRIPTION
Making field ORDERER_TRANSACTION in HeaderType deprecated, as it used only by the system channel.

Issue: https://github.com/hyperledger/fabric/issues/4206