### PR TITLE
Tag NPM packages from main branch as either next or next-unstable

### DIFF
--- a/.github/workflows/node-bindings.yml
+++ b/.github/workflows/node-bindings.yml
@@ -63,5 +63,5 @@ jobs:
       working-directory: bindings/node
       env:
         NPM_CONFIG_DRY_RUN: ${{ ( github.ref == 'refs/heads/main' || needs.ci_checks.outputs.publish_release == 'true' ) && 'false' || 'true' }}
-        NPM_PUBLISH_TAG: ${{ ( needs.ci_checks.outputs.publish_release == 'true' ) && 'latest' || 'unstable' }}
+        NPM_PUBLISH_TAG: ${{ ( needs.ci_checks.outputs.publish_release == 'true' ) && 'next' || 'next-unstable' }}
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Pushed commits to the main branch published NPM packages tagged as `unstable`, and release tags on the main branch published NPM packaged tagged as `latest`. This conflicted with NPM packages published from the 0.2.x branch and meant that the target Fabric version for the NPM package currently tagged `latest` varied depending on which branch had a release created most recently. The `latest` tag should always correspond to the current Fabric LTS release since it is the default version installed if a specific version is not specified.

Closes #191

<!--- IMPORTANT: DO NOT modify or disable lint rules without agreeing changes in an issue first! -->
<!--- Any changes to lint rules and breaking change detection should be made in a separate pull  -->
<!--- request with an associated issue.                                                          -->
<!--- Please include a link to the issue in the pull request and DO NOT adjust lint rules to fix -->
<!--- build breaks when submitting any other pull requests.                                      -->