### PR TITLE
Tag NPM packages from 0.1.x branch as either v1-latest or v1-unstable

### DIFF
--- a/.github/workflows/node-bindings.yml
+++ b/.github/workflows/node-bindings.yml
@@ -63,5 +63,5 @@ jobs:
       working-directory: bindings/node
       env:
         NPM_CONFIG_DRY_RUN: ${{ ( contains(fromJson('["refs/heads/main", "refs/heads/0.1.x"]'), github.ref) || needs.ci_checks.outputs.publish_release == 'true' ) && 'false' || 'true' }}
-        NPM_PUBLISH_TAG: ${{ ( needs.ci_checks.outputs.publish_release == 'true' ) && 'latest' || 'unstable' }}
+        NPM_PUBLISH_TAG: ${{ ( needs.ci_checks.outputs.publish_release == 'true' ) && 'v1-latest' || 'v1-unstable' }}
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,10 @@
 /build
 .idea
 .vscode
+
+/docs/protos.md
+/google
+/bindings/go-apiv1/**/*.pb.go
+/bindings/go-apiv2/**/*.pb.go
+/bindings/java/src
+/bindings/node/src


### PR DESCRIPTION
Pushed commits to the main branch published NPM packages tagged as `unstable`, and release tags on the main branch published NPM packaged tagged as `latest`. This conflicted with NPM packages published from the 0.2.x branch and meant that the target Fabric version for the NPM package currently tagged `latest` varied depending on which branch had a release created most recently. The `latest` tag should always correspond to the current Fabric LTS release since it is the default version installed if a specific version is not specified.

Also update .gitignore to exclude files that should not be checked in.

Contributes to #191

<!--- IMPORTANT: DO NOT modify or disable lint rules without agreeing changes in an issue first! -->
<!--- Any changes to lint rules and breaking change detection should be made in a separate pull  -->
<!--- request with an associated issue.                                                          -->
<!--- Please include a link to the issue in the pull request and DO NOT adjust lint rules to fix -->
<!--- build breaks when submitting any other pull requests.                                      -->