### PR TITLE
Replace deprecated set-output in Github Actions

### DIFF
--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -29,9 +29,9 @@ jobs:
         git fetch --tags origin
         TAGS=$(git tag --points-at HEAD | { grep -c "^v${BINDING_VERSION}$" || :; })
         if [ "${GITHUB_EVENT_NAME}" != "pull_request" ] && [ $TAGS -eq 1 ]; then
-          echo "::set-output name=publish_release::true"
+          echo "publish_release=true" >> $GITHUB_OUTPUT
         else
-          echo "::set-output name=publish_release::false"
+          echo "publish_release=false" >> $GITHUB_OUTPUT
         fi
 
   check_version:

--- a/.github/workflows/go-bindings.yml
+++ b/.github/workflows/go-bindings.yml
@@ -72,7 +72,7 @@ jobs:
         MAKEFILE_NAME: ${{ matrix.apiver == 'apiv1' && 'Makefile.apiv1' || 'Makefile' }}
 
     - name: Get commit message
-      run: echo "::set-output name=COMMIT_MESSAGE::$(git log --format=%B -n 1 $GITHUB_SHA)"
+      run: echo "COMMIT_MESSAGE=$(git log --format=%B -n 1 $GITHUB_SHA)" >> $GITHUB_OUTPUT
       id: get-commit-message
       working-directory: build
 


### PR DESCRIPTION
set-output is deprecated. This commit replaces it with the suggested change.